### PR TITLE
e2e: make tests more robust

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -51,6 +51,8 @@ func TestWebhook(t *testing.T) {
 	testutil.Ok(t, a.Start())
 	out, err = kubectl(context.Background(), e, "apply", "--filename", "manifests/webhook.yaml").CombinedOutput()
 	testutil.Ok(t, err, string(out))
+	out, err = kubectl(context.Background(), e, "wait", "--for", "condition=complete", "job", "cert-gen", "--namespace", "wavy", "--timeout", "1m").CombinedOutput()
+	testutil.Ok(t, err, string(out))
 	out, err = kubectl(context.Background(), e, "rollout", "status", "deployment", "wavy-webhook", "--namespace", "wavy").CombinedOutput()
 	testutil.Ok(t, err, string(out))
 	out, err = kubectl(context.Background(), e, "patch", "deployment", "alpine", "--patch", `{"metadata": {"annotations": {"wavy.squat.ai/enable": "true"}}}`).CombinedOutput()


### PR DESCRIPTION
Currently the e2e tests will ocasionally fail when a request is made to
the webhook before the CA has been injected into the webhook
configuration. This commit fixes the issue by ensuring that the job to
inject the CA has finished before patching the workload and thus
making a request to the webhook server.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
