### PR TITLE
x11: allow running as different user

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,7 @@ spec:
     - signal-desktop
     args:
     - --no-sandbox
-    securityContext:
-      runAsUser: 65534
-      runAsGroup: 65534
-    volumeMounts:
-    - name: config
-      mountPath: /nonexistent/.config
-  volumes:
-  - name: config
-    emptyDir: {}
+    - --user-data-dir=/root
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
This commit improves support for applications that run on X11.
Specifically, this commit allows the container running the X11
application to run as a different user than the container running
sway/Xwayland. This is accomplished by generating an .Xauthority file in
an init container and using that to authenticate with X.
This loosens the constraints for application developers/administrators
significantly and simplifies deployment, as well as finding applications
that "just work" with Wavy.

xref: https://github.com/wavyland/sway/pull/1

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
