### PR TITLE
ci: fix container job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,15 +51,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: 1.20.2
-    - name: Enable Experimental Docker CLI
-      run: |
-        echo $'{\n  "experimental": true\n}' | sudo tee /etc/docker/daemon.json
-        mkdir -p ~/.docker
-        echo $'{\n  "experimental": "enabled"\n}' | sudo tee ~/.docker/config.json
-        sudo service docker restart
-        docker version -f '{{.Client.Experimental}}'
-        docker version -f '{{.Server.Experimental}}'
-        docker buildx version
     - name: Container
       run: make container
 
@@ -93,15 +84,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: 1.20.2
-    - name: Enable Experimental Docker CLI
-      run: |
-        echo $'{\n  "experimental": true\n}' | sudo tee /etc/docker/daemon.json
-        mkdir -p ~/.docker
-        echo $'{\n  "experimental": "enabled"\n}' | sudo tee ~/.docker/config.json
-        sudo service docker restart
-        docker version -f '{{.Client.Experimental}}'
-        docker version -f '{{.Server.Experimental}}'
-        docker buildx version
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
       with:


### PR DESCRIPTION
Recent updates to the docker stack in GitHub actions means that
experimental features no longer need to be, and indeed cannot be,
enabled.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
