### PR TITLE
e2e: ensure clean cleanup

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -96,6 +96,7 @@ func TestWebhook(t *testing.T) {
 	testutil.Ok(t, err, string(out))
 	out, err = kubectl(context.Background(), e, "wait", "--for", "jsonpath={.status.phase}=Succeeded", "pod", "vnccapture", "--timeout", "1m").CombinedOutput()
 	testutil.Ok(t, err, string(out))
+	defer os.Remove(capture)
 	testutil.Ok(t, compareImages("test/signal.png", capture))
 }
 


### PR DESCRIPTION
This commit ensures that the cleanup of the e2e tests is clean. It
removes the capture.png file, which is not chmod-able to ensure the the
cleanup of the Kind cluster does not fail. This is a workaround until a
better solution, like the one mentioned in
https://github.com/efficientgo/e2e/pull/69 is available.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
